### PR TITLE
chore: exclude CONTRIBUTING.md file in template

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: '🧾 Checkout'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
           lfs: 'true'
           token: ${{ secrets.GH_BASIC }}
           ref: ${{ github.ref }}
 
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v4
         name: 💽 Setup .NET SDK
         with:
           # Use the .NET SDK from global.json in the root of the repository.

--- a/.github/workflows/self_update.yaml
+++ b/.github/workflows/self_update.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: '🧾 Checkout'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
           lfs: true

--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -31,7 +31,10 @@
   "sources": [
     {
       "source": "./src/",
-      "target": "./"
+      "target": "./",
+      "exclude": [
+        "**/CONTRIBUTING.md"
+      ]
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Please read our [code of conduct](#code-of-conduct). We do our best to treat oth
 
 ## Project Setup
 
-This is a C# nuget package, for use with the .NET SDK 6 or 7. As such, the `dotnet` tool will allow you to restore packages and build projects.
+This is a C# nuget package, for use with the .NET SDK 8. As such, the `dotnet` tool will allow you to restore packages and build projects.
 
 ## Code of Conduct
 

--- a/Chickensoft.GodotGameTemplate.csproj
+++ b/Chickensoft.GodotGameTemplate.csproj
@@ -23,7 +23,7 @@
 
     <IncludeContentInPack>true</IncludeContentInPack>
     <NoBuild>true</NoBuild>
-    <NoWarn>NU5128</NoWarn>
+    <NoWarn>NU5110;NU5111;NU5128</NoWarn>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>

--- a/Chickensoft.GodotGameTemplate.csproj
+++ b/Chickensoft.GodotGameTemplate.csproj
@@ -15,7 +15,7 @@
     <Title>GodotGame</Title>
     <Version>1.6.17</Version>
     <Description>C# game template for Godot 4 with debug launch configurations, testing (locally and on CI/CD), code coverage, dependency update checks, and spell check working out-of-the-box!</Description>
-    <Copyright>© 2023 Chickensoft</Copyright>
+    <Copyright>© 2024 Chickensoft</Copyright>
     <Company>Chickensoft</Company>
 
     <RepositoryType>git</RepositoryType>

--- a/Chickensoft.GodotGameTemplate.csproj
+++ b/Chickensoft.GodotGameTemplate.csproj
@@ -32,7 +32,7 @@
 
   <ItemGroup>
     <Content Include=".template.config/template.json" Pack="true" PackagePath=".template.config/template.json" />
-    <Content Include="src/**/*" Pack="true" PackagePath="src" />
+    <Content Include="src/**/*" Pack="true" PackagePath="src" Exclude="src/CONTRIBUTING.md" />
     <Content Remove="src/.git/" />
     <None Include="icon.png" Pack="true" PackagePath="" />
     <None Include="README.md" Pack="true" PackagePath="\" />

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.406"
+    "version": "8.0.401",
+    "rollForward": "major"
   }
 }


### PR DESCRIPTION
I found some additional chores while working, so I added them to this pull request as well. Hope that's ok.

This pull request now includes the following chores:

* Exclude `CONTRIBUTING.md` file from the template to prevent it from being included in generated projects.
* Update to `actions/checkout@v4` and `actions/setup-dotnet@v4`.
* Sync SDK version to match the GodotGame repository.
* Ignore `NU5110` and `NU5111` warnings related to the `src/coverage.ps1` file being outside the tools folder and not recognized by NuGet.
* Update copyright year to 2024.

Let me know if there is anything else, or if you would like any of these changes reverted.

Resolves #2.